### PR TITLE
Fix/error handler

### DIFF
--- a/lib/docusign_dtr/auth/error.rb
+++ b/lib/docusign_dtr/auth/error.rb
@@ -47,7 +47,13 @@ module DocusignDtr
       end
 
       def parsed_response
-        @parsed_response ||= @response.parsed_response&.transform_keys(&:to_sym) || {}
+        @parsed_response ||= error_object
+      end
+
+      def error_object
+        return { message: @response.parsed_response } if @response.parsed_response.instance_of?(String)
+
+        @response.parsed_response&.transform_keys(&:to_sym) || {}
       end
 
       def standard_error_message

--- a/spec/docusign_dtr/auth/error_spec.rb
+++ b/spec/docusign_dtr/auth/error_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe DocusignDtr::Auth::Error do
       end
     end
 
+    context 'bad request' do
+      let(:code) { 400 }
+      it 'returns correct error class' do
+        expect { subject.build }.to raise_error(StandardError)
+      end
+
+      context 'when parsed response is a string' do
+        let(:parsed_response) { 'Bad Request' }
+        it 'returns correct error class' do
+          expect { subject.build }.to raise_error(StandardError, 'Bad Request')
+        end
+      end
+    end
+
     context 'forbidden' do
       let(:code) { 403 }
       it 'returns correct error class' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167891683

https://developers.docusign.com/esign-rest-api/guides/status-and-error-codes

```In most cases, the response body contains a more detailed errorDetails structure when an error occurs. However, depending on the error, the server might return HTML in place of the errorDetails structure, or nothing in the case of certain error types. The table of Error Codes and Associated Messages lists the possible error codes and messages.```